### PR TITLE
Fix github and npmjs linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   },
   "keywords": [ "minecraft", "information", "minecraft-information", "discord.js", "javascript", "minecraft-info", "info-minecraft" ],
   "homepage": "hthttps://github.com/LilBartrap999/minecraft-information#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LilBartrap999/minecraft-information.git"
+  },
   "url": "https://github.com/LilBartrap999/minecraft-information/issues",
   "author": "LilBartrap <contact.lilbartrap@gmail.com> (https://mc-info.ga/)",
   "email": "contact.lilbartrap@gmail.com",


### PR DESCRIPTION
This PR fixes repository not appearing on npmjs.com website.